### PR TITLE
Small fixes

### DIFF
--- a/ros.el
+++ b/ros.el
@@ -36,13 +36,16 @@
 
 (require 's)
 (require 'with-shell-interpreter)
-(require 'tramp-container)
 (require 'kv)
 (require 'cl-lib)
 (require 'transient)
 (require 'hydra)
 (require 'grep)
 (require 'string-inflection)
+(eval-and-compile
+  (if (>= emacs-major-version 29)
+      (require 'tramp-container)
+    (require 'docker-tramp)))
 
 (defvar ros-tramp-prefix "")
 

--- a/ros.el
+++ b/ros.el
@@ -102,8 +102,9 @@
 
 (defun ros-shell-command-to-string (cmd &optional use-default-directory)
   (let ((path (if use-default-directory default-directory (concat (ros-current-tramp-prefix) "~"))))
-    (with-shell-interpreter :path path :form
-      (s-trim(shell-command-to-string (format "/bin/bash  -c \"%s && %s\" | sed -r \"s/\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g\"" (ros-current-source-command) cmd))))))
+    (with-shell-interpreter
+     :path path
+     :form (s-trim (shell-command-to-string (format "/bin/bash  -c \"%s && %s\" | sed -r \"s/\x1B\\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g\"" (ros-current-source-command) cmd))))))
 
 (defun ros-shell-command-to-list (cmd)
   (split-string (ros-shell-command-to-string cmd) "\n" t  "[\s\f\t\n\r\v\\]+"))

--- a/ros.el
+++ b/ros.el
@@ -36,7 +36,7 @@
 
 (require 's)
 (require 'with-shell-interpreter)
-(require 'docker-tramp)
+(require 'tramp-container)
 (require 'kv)
 (require 'cl-lib)
 (require 'transient)

--- a/ros.el
+++ b/ros.el
@@ -43,7 +43,6 @@
 (require 'hydra)
 (require 'grep)
 (require 'string-inflection)
-(require 'avy)
 
 (defvar ros-tramp-prefix "")
 
@@ -192,7 +191,12 @@
   (let ((avy-all-windows nil))
     (save-excursion
       (goto-char (point-min))
-      (avy--line nil (point-min) (point-max)))))
+      (cond
+       ((require 'avy nil nil)
+        (avy--line nil (point-min) (point-max)))
+       ((require 'consult nil nil)
+        (marker-position (consult-line)))
+       (t (user-error "You need to install `avy' or `consult' to use this feature."))))))
 
 (defun ros-insert-message (msg)
   (interactive (list (ros-completing-read-message)))


### PR DESCRIPTION
- Replace `docker-tramp` with built-in `tramp-container`.
- Fallback to `consult` if `avy` is not installed.